### PR TITLE
update-20200711-correct ref and citation command for bibtex

### DIFF
--- a/data/chap02.tex
+++ b/data/chap02.tex
@@ -449,14 +449,14 @@ $\beta_a=\lnot \left(\left[s_1\lor s_2\lor \cdots\lor s_m\right]^T\right)$，而
 
 使用bibtex时要特别注意：
 
-（1）中文参考文献\upcite{cnarticle}，需要在bib文件对应文献条目中
+中文参考文献\upcite{cnarticle}，需要在bib文件对应文献条目中
 增加\verb|language|域并设为\verb|zh|，英文此项可不填，之后由\verb|bstutf8|统一处理
 (具体就是决定一些文献在中英文不同环境下的显示格式，如等、etc)。
 若使用\verb|JabRef|，则你可按下面步骤来设置：
 选择\textsf{Options}$\rightarrow$\textsf{Set Up General Fields}，
 在\verb|General:|后加入\verb|language|就可以了。
 
-（2）上标形式的命令为upcite，而行内非上标形式命令式cite，注意与使用biber时的用法进行区分。
+
 
 \section{代码高亮}
 有些时候我们需要在论文中引入一段代码，用来衬托正文的内容，或者体现关键思路的实现。

--- a/nudtpaper.cls
+++ b/nudtpaper.cls
@@ -5,28 +5,28 @@
 %% The original source files were:
 %%
 %% nudtpaper.dtx  (with options: `cls')
-%%
+%% 
 %% This is a generated file.
-%%
+%% 
 %% Copyright (C) 2020 by Liu Benyuan <liubenyuan@gmail.com>
-%%
+%% 
 %% This file may be distributed and/or modified under the
 %% conditions of the LaTeX Project Public License, either version 1.3a
 %% of this license or (at your option) any later version.
 %% The latest version of this license is in:
-%%
+%% 
 %% http://www.latex-project.org/lppl.txt
-%%
+%% 
 %% and version 1.3a or later is part of all distributions of LaTeX
 %% version 2004/10/01 or later.
-%%
+%% 
 %% To produce the documentation run the original source files ending with `.dtx'
 %% through LaTeX.
-%%
+%% 
 %% Any Suggestions : LiuBenYuan <liubenyuan@gmail.com>
 %% Thanks Xue Ruini <xueruini@gmail.com> for the thuthesis class!
 %% Thanks sofoot for the original NUDT paper class!
-%%
+%% 
 \NeedsTeXFormat{LaTeX2e}[1999/12/01]
 \ProvidesClass{nudtpaper}
 [2020/07/01 v2.8 NUDT paper template]
@@ -91,7 +91,7 @@
 \RequirePackage[backend=biber,style=gb7714-2015,gbalign=gb7714-2015,%
 gbnamefmt=lowercase,gbpub=false]{biblatex}%
 \addbibresource[location=local]{ref/refs.bib}
-\setlength{\bibitemsep}{0ex}
+\setlength{\bibitemsep}{1pt}
 \setlength{\bibnamesep}{0ex}
 \setlength{\bibinitsep}{0ex}
 \setlength{\biblabelsep}{6pt}
@@ -179,7 +179,11 @@ gbnamefmt=lowercase,gbpub=false]{biblatex}%
 \fi
 \else
 \RequirePackage[numbers,sort&compress,square]{natbib}
-\newcommand{\upcite}[1]{\textsuperscript{\cite{#1}}} % 上标形式引用
+\let\newcite=\cite
+\let\parencite=\newcite
+\let\inlinecite=\newcite
+\newcommand{\upcite}[1]{\textsuperscript{\newcite{#1}}} % 上标形式引用
+\renewcommand{\cite}[1]{\textsuperscript{\newcite{#1}}} % 上标形式引用
 \fi
 \RequirePackage[colorlinks=true,linkcolor=blue,citecolor=red,pdfborder=0 1 1]{hyperref}
 \RequirePackage{datetime}

--- a/nudtpaper.dtx
+++ b/nudtpaper.dtx
@@ -299,7 +299,7 @@
 %    \end{macrocode}
 %    \begin{macrocode}
 %<*thesis>
-\documentclass[doctor,twoside,biber,resumebib]{nudtpaper}
+\documentclass[doctor,twoside,biber,resumebib,fz]{nudtpaper}
 \usepackage{mynudt}
 
 %</thesis>
@@ -489,6 +489,7 @@
 \ifisbiber
 {\hyphenpenalty=500 %
 \tolerance=9900 %
+\renewcommand{\baselinestretch}{1.35}
 \printbibliography[heading=bibliography, title=参考文献]
 
 }
@@ -709,7 +710,7 @@
 \RequirePackage[backend=biber,style=gb7714-2015,gbalign=gb7714-2015,%
 gbnamefmt=lowercase,gbpub=false]{biblatex}%
 \addbibresource[location=local]{ref/refs.bib}
-\setlength{\bibitemsep}{0ex}
+\setlength{\bibitemsep}{1pt}
 \setlength{\bibnamesep}{0ex}
 \setlength{\bibinitsep}{0ex}
 \setlength{\biblabelsep}{6pt}
@@ -797,7 +798,11 @@ gbnamefmt=lowercase,gbpub=false]{biblatex}%
 \fi
 \else
 \RequirePackage[numbers,sort&compress,square]{natbib}
-\newcommand{\upcite}[1]{\textsuperscript{\cite{#1}}} % 上标形式引用
+\let\newcite=\cite
+\let\parencite=\newcite
+\let\inlinecite=\newcite
+\newcommand{\upcite}[1]{\textsuperscript{\newcite{#1}}} % 上标形式引用
+\renewcommand{\cite}[1]{\textsuperscript{\newcite{#1}}} % 上标形式引用
 \fi
 \RequirePackage[colorlinks=true,linkcolor=blue,citecolor=red,pdfborder=0 1 1]{hyperref}
 \RequirePackage{datetime}

--- a/ref/refs.bib
+++ b/ref/refs.bib
@@ -1,8 +1,5 @@
 % This file was created with JabRef 2.5.
 % Encoding: UTF-8
-
-
-% Encoding: UTF-8
 @article{ref-1-1-周融,
 author    = {周融 and 任志国 and 杨尚雷 and others},
 title     = {对新形势下毕业设计管理工作的思考与实践},
@@ -65,7 +62,7 @@ note       = {news},
 
 
 @newspaper{ref-7-7-French,
-author    = {French W},
+author    = {French, W},
 title     = {Between Silences:A Voice from China},
 journal   = {Atlantic Weekly},
 date      = {1987-08-15},
@@ -88,6 +85,7 @@ pages     = {12-17},
 author    = {Spivak, G},
 title     = {Can the Subaltern Speak? },
 editor= {Nelson, C and Grossberg, L},
+editortype={editor},
 booktitle = {Victory in Limbo: Imigism },
 address   = {Urbana},
 publisher = {University of Illinois Press},
@@ -99,13 +97,15 @@ pages     = {271-313},
 @inproceedings{ref-10-10-Almarza,
 author    = {Almarza, G G},
 title     = {Student Foreign Language Teacher’s Knowledge Growth},
-editor= {Freeman, D and Richards J C},
+editor= {Freeman, D and Richards, J C},
+editortype={editor},
 booktitle = {Teacher Learning in Language Teaching},
 address   = {New York},
 publisher = {Walley},
 date      = {1998},
 pages     = {200-205},
 }
+
 
 
 

--- a/thesis.tex
+++ b/thesis.tex
@@ -5,28 +5,28 @@
 %% The original source files were:
 %%
 %% nudtpaper.dtx  (with options: `thesis')
-%%
+%% 
 %% This is a generated file.
-%%
+%% 
 %% Copyright (C) 2020 by Liu Benyuan <liubenyuan@gmail.com>
-%%
+%% 
 %% This file may be distributed and/or modified under the
 %% conditions of the LaTeX Project Public License, either version 1.3a
 %% of this license or (at your option) any later version.
 %% The latest version of this license is in:
-%%
+%% 
 %% http://www.latex-project.org/lppl.txt
-%%
+%% 
 %% and version 1.3a or later is part of all distributions of LaTeX
 %% version 2004/10/01 or later.
-%%
+%% 
 %% To produce the documentation run the original source files ending with `.dtx'
 %% through LaTeX.
-%%
+%% 
 %% Any Suggestions : LiuBenYuan <liubenyuan@gmail.com>
 %% Thanks Xue Ruini <xueruini@gmail.com> for the thuthesis class!
 %% Thanks sofoot for the original NUDT paper class!
-%%
+%% 
 %1. 规范硕士导言
 % \documentclass[master,ttf]{nudtpaper}
 %2. 规范博士导言
@@ -106,6 +106,7 @@
 \ifisbiber
 {\hyphenpenalty=500 %
 \tolerance=9900 %
+\renewcommand{\baselinestretch}{1.35}
 \printbibliography[heading=bibliography, title=参考文献]
 
 }


### PR DESCRIPTION
1. 修正了bib文件，使编者类型正确显示
2. 统一了引用命令，无论式bibtex还是biber都一样，上标用cite、upcite，非上标用parencite，inlinecite
3. biblatex生成的文献表的baselinestretch扩展到1.35，使与利用bibtex时，用enumerte环境生成的文献表行距基本一致。
4. 波浪号字体没有换，texlive应该是自带，因为xecjk也是利用该字体生成的symbol表，一般不会缺少，如果有更好的字符，你就换一下吧。