### PR TITLE
更新模板中博士论文的英文封面

### DIFF
--- a/nudtpaper.cls
+++ b/nudtpaper.cls
@@ -407,9 +407,9 @@ gbnamefmt=lowercase,gbpub=false]{biblatex}%
 \newcommand\cabstractname{摘\hspace{1em}要}
 \newcommand\eabstractname{ABSTRACT}
 \newcommand\ckeywordsname{关键词}
-\newcommand\ckeywords[1]{{\hei\xiaosi \ckeywordsname: #1}}
+\newcommand\ckeywords[1]{{\hei\xiaosi \ckeywordsname：#1}}
 \newcommand\ekeywordsname{Key Words}
-\newcommand\ekeywords[1]{\textbf{\textsf{\xiaosi \ekeywordsname: #1}}}
+\newcommand\ekeywords[1]{\textsf{\xiaosi \ekeywordsname：#1}}
 \newenvironment{cabstract}{%
     \chapter{\cabstractname}
     \xiaosi


### PR DESCRIPTION
根据word模板，博士论文英文封面页应为Ph.D，而非PhD